### PR TITLE
Adds the ability to define alternate names for datatypes on XNAT

### DIFF
--- a/arcana/citation.py
+++ b/arcana/citation.py
@@ -8,7 +8,7 @@ class Citation(object):
                  month=None, proceedings=None, url=None, pdf=None,
                  doi=None):
         self._short_name = short_name
-        self._authors = authors
+        self._authors = tuple(authors)
         self._title = title
         self._year = year
         self._journal = journal

--- a/arcana/citation.py
+++ b/arcana/citation.py
@@ -1,4 +1,6 @@
 from builtins import object
+
+
 class Citation(object):
 
     def __init__(self, short_name, authors, title, year, journal=None,
@@ -36,6 +38,22 @@ class Citation(object):
             self.url == other.url and
             self.pdf == other.pdf and
             self.doi == other.doi)
+
+    def __hash__(self):
+        return (hash(self.short_name) ^
+                hash(self.authors) ^
+                hash(self.title) ^
+                hash(self.year) ^
+                hash(self.journal) ^
+                hash(self.volume) ^
+                hash(self.issue) ^
+                hash(self.pages) ^
+                hash(self.institute) ^
+                hash(self.month) ^
+                hash(self.proceedings) ^
+                hash(self.url) ^
+                hash(self.pdf) ^
+                hash(self.doi))
 
     def __ne__(self, other):
         return not (self == other)

--- a/arcana/data_format.py
+++ b/arcana/data_format.py
@@ -144,8 +144,9 @@ class DataFormat(object):
         return self._within_dir_exts
 
     @property
-    def xnat_resource_name(self):
-        return self.name.upper()
+    def xnat_resource_names(self):
+        "Lists acceptable XNAT resource names in order of preference"
+        return (self.name.upper(),) + self.alternate_names
 
     def converter_from(self, data_format):
         if data_format == self:

--- a/arcana/data_format.py
+++ b/arcana/data_format.py
@@ -157,8 +157,9 @@ class DataFormat(object):
             raise ArcanaNoConverterError(
                 "There is no converter to convert {} to {}, available:\n{}"
                 .format(self, data_format,
-                        '\n'.join('{} <- {}'.format(k, v)
-                                  for k, v in self._converter.items())))
+                        '\n'.join(
+                            '{} <- {}'.format(k, v)
+                            for k, v in self._converters.items())))
         return converter_cls(data_format, self)
 
     @classmethod

--- a/arcana/data_format.py
+++ b/arcana/data_format.py
@@ -104,7 +104,7 @@ class DataFormat(object):
     def __repr__(self):
         return ("DataFormat(name='{}', extension='{}', directory={}{})"
                 .format(self.name, self.extension, self.directory,
-                        ('within_dir_extension={}'.format(
+                        (', within_dir_extension={}'.format(
                             self.within_dir_exts)
                          if self.directory else '')))
 
@@ -155,8 +155,10 @@ class DataFormat(object):
             converter_cls = self._converters[data_format.name]
         except KeyError:
             raise ArcanaNoConverterError(
-                "There is no converter to convert {} to {}"
-                .format(self, data_format))
+                "There is no converter to convert {} to {}, available:\n{}"
+                .format(self, data_format,
+                        '\n'.join('{} <- {}'.format(k, v)
+                                  for k, v in self._converter.items())))
         return converter_cls(data_format, self)
 
     @classmethod

--- a/arcana/dataset/explicit.py
+++ b/arcana/dataset/explicit.py
@@ -83,7 +83,12 @@ class Dataset(BaseDataset):
                 hash(self.visit_id))
 
     def __lt__(self, other):
-        return self.id < other.id
+        if isinstance(self.id, int) and isinstance(other.id, str):
+            return True
+        elif isinstance(self.id, str) and isinstance(other.id, int):
+            return False
+        else:
+            return self.id < other.id
 
     def find_mismatch(self, other, indent=''):
         mismatch = super(Dataset, self).find_mismatch(other, indent)

--- a/arcana/dataset/match.py
+++ b/arcana/dataset/match.py
@@ -299,9 +299,9 @@ class DatasetMatch(BaseDataset, BaseMatch):
             matches = list(node.datasets)
         if not matches:
             raise ArcanaDatasetMatchError(
-                "No dataset names in {} match '{}' pattern, found: {}"
-                .format(node, self.pattern,
-                        '\n'.join(d.name for d in node.datasets)))
+                "No dataset names in {}:{} match '{}' pattern, found: {}"
+                .format(node.subject_id, node.visit_id, self.pattern,
+                        ', '.join(d.name for d in node.datasets)))
         if self.id is not None:
             filtered = [d for d in matches if d.id == self.id]
             if not filtered:
@@ -316,7 +316,8 @@ class DatasetMatch(BaseDataset, BaseMatch):
             filtered = []
             for dataset in matches:
                 values = dataset.dicom_values(
-                    list(self.dicom_tags.keys()), repository_login=repository_login)
+                    list(self.dicom_tags.keys()),
+                    repository_login=repository_login)
                 if self.dicom_tags == values:
                     filtered.append(dataset)
             if not filtered:

--- a/arcana/dataset/spec.py
+++ b/arcana/dataset/spec.py
@@ -196,7 +196,7 @@ class DatasetSpec(BaseDataset, BaseSpec):
                 BaseSpec.__eq__(self, other))
 
     def __hash__(self):
-        return (BaseDataset.__hash__(self) and
+        return (BaseDataset.__hash__(self) ^
                 BaseSpec.__hash__(self))
 
     def __repr__(self):
@@ -249,7 +249,7 @@ class FieldSpec(BaseField, BaseSpec):
         return (BaseField.__eq__(self, other) and
                 BaseSpec.__eq__(self, other))
 
-    def hash(self):
+    def __hash__(self):
         return (BaseField.__hash__(self) ^ BaseSpec.__hash__(self))
 
     def find_mismatch(self, other, indent=''):

--- a/arcana/dataset/spec.py
+++ b/arcana/dataset/spec.py
@@ -115,7 +115,7 @@ class BaseSpec(object):
                 "'{}' study".format(self.pipeline_name, self.study))
         if self.name not in pipeline.output_names:
             raise ArcanaOutputNotProducedException(
-                "'{}' is not produced by {} with options: {}".format(
+                "'{}' is not produced by {} with options:\n{}".format(
                     self.name, self.study,
                     '\n'.join('{}={}'.format(o.name, o.value)
                               for o in self.study.options)))

--- a/arcana/interfaces/iterators.py
+++ b/arcana/interfaces/iterators.py
@@ -60,24 +60,24 @@ class InputSessions(BaseInterface):
         return outputs
 
 
-class SessionRepositoryrtInputSpec(TraitedSpec):
+class SessionReportInputSpec(TraitedSpec):
 
     sessions = traits.List(traits.Str)
     subjects = traits.List(traits.Str)
 
 
-class SessionRepositoryrtOutputSpec(TraitedSpec):
+class SessionReportOutputSpec(TraitedSpec):
 
     subject_session_pairs = traits.List(traits.Tuple(traits.Str, traits.Str))
 
 
-class SessionRepositoryrt(BaseInterface):
+class SessionReport(BaseInterface):
     """
     Basically an IndentityInterface for joining over sessions
     """
 
-    input_spec = SessionRepositoryrtInputSpec
-    output_spec = SessionRepositoryrtOutputSpec
+    input_spec = SessionReportInputSpec
+    output_spec = SessionReportOutputSpec
 
     def _run_interface(self, runtime):
         return runtime
@@ -89,18 +89,18 @@ class SessionRepositoryrt(BaseInterface):
         return outputs
 
 
-class SubjectRepositoryrtSpec(TraitedSpec):
+class SubjectReportSpec(TraitedSpec):
 
     subjects = traits.List(traits.Str)
 
 
-class SubjectRepositoryrt(BaseInterface):
+class SubjectReport(BaseInterface):
     """
     Basically an IndentityInterface for joining over subjects
     """
 
-    input_spec = SubjectRepositoryrtSpec
-    output_spec = SubjectRepositoryrtSpec
+    input_spec = SubjectReportSpec
+    output_spec = SubjectReportSpec
 
     def _run_interface(self, runtime):
         return runtime
@@ -111,18 +111,18 @@ class SubjectRepositoryrt(BaseInterface):
         return outputs
 
 
-class VisitRepositoryrtSpec(TraitedSpec):
+class VisitReportSpec(TraitedSpec):
 
     sessions = traits.List(traits.Str)
 
 
-class VisitRepositoryrt(BaseInterface):
+class VisitReport(BaseInterface):
     """
     Basically an IndentityInterface for joining over sessions
     """
 
-    input_spec = VisitRepositoryrtSpec
-    output_spec = VisitRepositoryrtSpec
+    input_spec = VisitReportSpec
+    output_spec = VisitReportSpec
 
     def _run_interface(self, runtime):
         return runtime
@@ -133,24 +133,24 @@ class VisitRepositoryrt(BaseInterface):
         return outputs
 
 
-class SubjectSessionRepositoryrtInputSpec(TraitedSpec):
+class SubjectSessionReportInputSpec(TraitedSpec):
 
     subject_session_pairs = traits.List(
         traits.List(traits.Tuple(traits.Str, traits.Str)))
 
 
-class SubjectSessionRepositoryrtOutputSpec(TraitedSpec):
+class SubjectSessionReportOutputSpec(TraitedSpec):
 
     subject_session_pairs = traits.List(traits.Tuple(traits.Str, traits.Str))
 
 
-class SubjectSessionRepositoryrt(BaseInterface):
+class SubjectSessionReport(BaseInterface):
     """
     Basically an IndentityInterface for joining over subject-session pairs
     """
 
-    input_spec = SubjectSessionRepositoryrtInputSpec
-    output_spec = SubjectSessionRepositoryrtOutputSpec
+    input_spec = SubjectSessionReportInputSpec
+    output_spec = SubjectSessionReportOutputSpec
 
     def _run_interface(self, runtime):
         return runtime
@@ -162,7 +162,7 @@ class SubjectSessionRepositoryrt(BaseInterface):
         return outputs
 
 
-class PipelineRepositoryrtInputSpec(TraitedSpec):
+class PipelineReportInputSpec(TraitedSpec):
     subject_session_pairs = traits.List(traits.Tuple(
         traits.Str, traits.Str),
         desc="Subject & session pairs from per-session sink")
@@ -173,7 +173,7 @@ class PipelineRepositoryrtInputSpec(TraitedSpec):
     project = traits.Str(desc="Project ID from per-project sink")
 
 
-class PipelineRepositoryrtOutputSpec(TraitedSpec):
+class PipelineReportOutputSpec(TraitedSpec):
     subject_session_pairs = traits.List(traits.Tuple(
         traits.Str, traits.Str),
         desc="Session & subject pairs from per-session sink")
@@ -181,10 +181,10 @@ class PipelineRepositoryrtOutputSpec(TraitedSpec):
     project = traits.Str(desc="Project ID from per-project sink")
 
 
-class PipelineRepositoryrt(BaseInterface):
+class PipelineReport(BaseInterface):
 
-    input_spec = PipelineRepositoryrtInputSpec
-    output_spec = PipelineRepositoryrtOutputSpec
+    input_spec = PipelineReportInputSpec
+    output_spec = PipelineReportOutputSpec
 
     def _run_interface(self, runtime):
         return runtime

--- a/arcana/repository/xnat.py
+++ b/arcana/repository/xnat.py
@@ -230,18 +230,19 @@ class XnatSource(RepositorySource, XnatMixin):
 
     @classmethod
     def get_resource(cls, xdataset, dataset):
-        try:
-            xresource = xdataset.resources[
-                dataset.format.xnat_resource_name]
-        except KeyError:
-            raise ArcanaError(
-                "'{}' dataset is not available in '{}' format, "
-                "available resources are '{}'"
-                .format(
-                    dataset.name, dataset.format.xnat_resource_name,
-                    "', '".join(r.label
-                                 for r in list(dataset.resources.values()))))
-        return xresource
+        for resource_name in dataset.format.xnat_resource_names:
+            try:
+                return xdataset.resources[resource_name]
+            except KeyError:
+                continue
+        raise ArcanaError(
+            "'{}' dataset is not available in '{}' format(s), "
+            "available resources are '{}'"
+            .format(
+                dataset.name,
+                "', '".join(dataset.format.xnat_resource_names),
+                "', '".join(
+                    r.label for r in list(dataset.resources.values()))))
 
     @classmethod
     def get_digests(cls, resource):
@@ -279,7 +280,7 @@ class XnatSource(RepositorySource, XnatMixin):
         data_path = os.path.join(
             expanded_dir, session_label, 'scans',
             (xdataset.id + '-' + special_char_re.sub('_', xdataset.type)),
-            'resources', dataset.format.xnat_resource_name, 'files')
+            'resources', xresource.label, 'files')
         if not dataset.format.directory:
             # If the dataformat is not a directory (e.g. DICOM),
             # attempt to locate a single file within the resource
@@ -913,8 +914,7 @@ class XnatRepository(Repository):
         """
         datasets = []
         for xdataset in xsession.scans.values():
-            data_format = DataFormat.by_name(
-                guess_data_format(xdataset))
+            data_format = guess_data_format(xdataset)
             datasets.append(Dataset(
                 xdataset.type, format=data_format, derived=derived,  # @ReservedAssignment @IgnorePep8
                 frequency=freq, path=None, id=xdataset.id,
@@ -1015,22 +1015,27 @@ class XnatRepository(Repository):
         return (subj_label, sess_label)
 
 
-def guess_data_format(dataset):
-    # Use a set here as in some strange cases I can get two references
-    # to the same resource
-    dataset_formats = set(r for r in dataset.resources.values()
-                          if r.label.lower() in DataFormat.by_names)
-    if len(dataset_formats) > 1:
+def guess_data_format(xdataset):
+    # Use a set here as in some cases there are multiple resources
+    # the same format (e.g. DICOM + secondary)
+    dataset_formats = set()
+    for resource in xdataset.resources.values():
+        try:
+            dataset_formats.add(DataFormat.by_names[
+                resource.label.lower()])
+        except KeyError:
+            logger.debug("Ignoring resource '{}' in dataset {}"
+                         .format(resource.label, xdataset.label))
+    if not dataset_formats:
         raise ArcanaError(
-            "Multiple valid resources '{}' for '{}' dataset, please pass "
-            "'data_format' to 'download_dataset' method to speficy resource to"
-            "download".format(
+            "No recognised data formats for '{}' dataset (available "
+            "resources are '{}')".format(
+                xdataset.type, "', '".join(xdataset.resources)))
+    elif len(dataset_formats) > 1:
+        raise ArcanaError(
+            "Multiple valid data-formats '{}' for '{}' dataset, please "
+            "pass 'data_format' to 'download_dataset' method to speficy"
+            " resource to download".format(
                 "', '".join(f.label for f in dataset_formats),
-                dataset.type))
-    elif not dataset_formats:
-        raise ArcanaError(
-            "No recognised data formats for '{}' dataset (available resources "
-            "are '{}')".format(
-                dataset.type, "', '".join(
-                    r.label for r in dataset.resources.values())))
-    return next(iter(dataset_formats)).label
+                xdataset.type))
+    return next(iter(dataset_formats))

--- a/arcana/repository/xnat.py
+++ b/arcana/repository/xnat.py
@@ -1019,18 +1019,19 @@ def guess_data_format(xdataset):
     # Use a set here as in some cases there are multiple resources
     # the same format (e.g. DICOM + secondary)
     dataset_formats = set()
-    for resource in xdataset.resources.values():
+    for xresource in xdataset.resources.values():
         try:
             dataset_formats.add(DataFormat.by_names[
-                resource.label.lower()])
+                xresource.label.lower()])
         except KeyError:
             logger.debug("Ignoring resource '{}' in dataset {}"
-                         .format(resource.label, xdataset.label))
+                         .format(xresource.label, xdataset.type))
     if not dataset_formats:
         raise ArcanaError(
             "No recognised data formats for '{}' dataset (available "
             "resources are '{}')".format(
-                xdataset.type, "', '".join(xdataset.resources)))
+                xdataset.type, "', '".join(
+                    r.label for r in xdataset.resources.values())))
     elif len(dataset_formats) > 1:
         raise ArcanaError(
             "Multiple valid data-formats '{}' for '{}' dataset, please "

--- a/arcana/runner/base.py
+++ b/arcana/runner/base.py
@@ -106,8 +106,8 @@ class BaseRunner(object):
         return workflow.run(plugin=self._plugin)
 
     def _connect_to_repository(self, pipeline, complete_workflow,
-                            subject_ids=None, visit_ids=None,
-                            already_connected=None):
+                               subject_ids=None, visit_ids=None,
+                               already_connected=None):
         if already_connected is None:
             already_connected = {}
         try:

--- a/arcana/runner/base.py
+++ b/arcana/runner/base.py
@@ -13,8 +13,8 @@ from arcana.exception import (
     ArcanaUsageError)
 from arcana.dataset.base import BaseDataset, BaseField
 from arcana.interfaces.iterators import (
-    InputSessions, PipelineRepositoryrt, InputSubjects, SubjectRepositoryrt,
-    VisitRepositoryrt, SubjectSessionRepositoryrt, SessionRepositoryrt)
+    InputSessions, PipelineReport, InputSubjects, SubjectReport,
+    VisitReport, SubjectSessionReport, SessionReport)
 from arcana.utils import PATH_SUFFIX, FIELD_SUFFIX
 
 logger = getLogger('Arcana')
@@ -79,7 +79,7 @@ class BaseRunner(object):
 
         Returns
         -------
-        report : RepositoryrtNode
+        report : ReportNode
             The final report node, which can be connected to subsequent
             pipelines
         """
@@ -230,7 +230,7 @@ class BaseRunner(object):
         # Create a report node for holding a summary of all the sessions/
         # subjects that were sunk. This is used to connect with dependent
         # pipelines into one large connected pipeline.
-        report = pipeline.create_node(PipelineRepositoryrt(), 'report')
+        report = pipeline.create_node(PipelineReport(), 'report')
         # Connect all outputs to the repository sink
         for freq, outputs in pipeline._outputs.items():
             # Create a new sink for each frequency level (i.e 'per_session',
@@ -347,12 +347,12 @@ class BaseRunner(object):
         """
         if freq == 'per_session':
             session_outputs = JoinNode(
-                SessionRepositoryrt(), joinsource=sessions,
+                SessionReport(), joinsource=sessions,
                 joinfield=['subjects', 'sessions'],
                 name=pipeline.name + '_session_outputs', wall_time=20,
                 memory=4000)
             subject_session_outputs = JoinNode(
-                SubjectSessionRepositoryrt(), joinfield='subject_session_pairs',
+                SubjectSessionReport(), joinfield='subject_session_pairs',
                 joinsource=subjects,
                 name=pipeline.name + '_subject_session_outputs', wall_time=20,
                 memory=4000)
@@ -365,7 +365,7 @@ class BaseRunner(object):
                 output_summary, 'subject_session_pairs')
         elif freq == 'per_subject':
             subject_output_summary = JoinNode(
-                SubjectRepositoryrt(), joinsource=subjects, joinfield='subjects',
+                SubjectReport(), joinsource=subjects, joinfield='subjects',
                 name=pipeline.name + '_subject_summary_outputs', wall_time=20,
                 memory=4000)
             workflow.connect(sink, 'subject_id',
@@ -374,7 +374,7 @@ class BaseRunner(object):
                              output_summary, 'subjects')
         elif freq == 'per_visit':
             visit_output_summary = JoinNode(
-                VisitRepositoryrt(), joinsource=sessions, joinfield='sessions',
+                VisitReport(), joinsource=sessions, joinfield='sessions',
                 name=pipeline.name + '_visit_summary_outputs', wall_time=20,
                 memory=4000)
             workflow.connect(sink, 'visit_id',

--- a/arcana/study/base.py
+++ b/arcana/study/base.py
@@ -1,5 +1,6 @@
 from past.builtins import basestring
 from builtins import object
+from future.utils import PY3
 from itertools import chain
 import sys
 import types
@@ -80,8 +81,11 @@ class Study(object):
                  subject_ids=None, visit_ids=None,
                  enforce_inputs=True, reprocess=False):
         try:
-            if not issubclass(type(self).__dict__['__metaclass__'],
-                              StudyMetaClass):
+#             if PY3:
+#                 metaclass = type(type(self))
+#             else:
+            metaclass = type(self).__dict__['__metaclass__']
+            if not issubclass(metaclass, StudyMetaClass):
                 raise KeyError
         except KeyError:
             raise ArcanaUsageError(

--- a/arcana/study/multi.py
+++ b/arcana/study/multi.py
@@ -1,4 +1,5 @@
 from past.builtins import basestring
+from future.utils import PY3
 from builtins import object
 from itertools import chain
 from nipype.interfaces.utility import IdentityInterface
@@ -78,8 +79,11 @@ class MultiStudy(Study):
     def __init__(self, name, repository, runner, inputs, options=None,
                  **kwargs):
         try:
-            if not issubclass(type(self).__dict__['__metaclass__'],
-                              MultiStudyMetaClass):
+#             if PY3:
+#                 metaclass = type(type(self))
+#             else:
+            metaclass = type(self).__dict__['__metaclass__']
+            if not issubclass(metaclass, MultiStudyMetaClass):
                 raise KeyError
         except KeyError:
             raise ArcanaUsageError(


### PR DESCRIPTION
In order to handle DICOM datasets which use the 'secondary' resource name on XNAT, data formats can define alternate names which are checked when determining the format of the resource